### PR TITLE
Add go v1.13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - 1.12.x
+  - 1.13.x
 
 services:
   - docker

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/seqsense/s3sync
 
-go 1.12
+go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.20.11


### PR DESCRIPTION
- Add golang version `1.13.x` support to `travis.yaml`
- Update `go.mod` to golang version `1.13`