### PR TITLE
Renovate: Configure automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,13 @@
             "schedule": [
                 "on the first day of the month"
             ]
+        },
+        {
+            "packagePatterns": [
+                "^github.com/aws/aws-sdk-go"
+            ],
+            "updateTypes": ["patch"],
+            "automerge": true
         }
     ],
     "timezone": "Asia/Tokyo"


### PR DESCRIPTION
We decided to automerge some reliable packages to save review time of Renovate PRs. 