### PR TITLE
Support Go 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.12.x
   - 1.13.x
+  - 1.14.x
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ services:
 
 env:
   global:
-    - GO111MODULE=on
       # These dummy credentials are necessary for running tests against
       # localstack s3 service
     - AWS_ACCESS_KEY_ID=foo

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/seqsense/s3sync
 
-go 1.13
+go 1.14
 
 require github.com/aws/aws-sdk-go v1.32.11


### PR DESCRIPTION
and remove test for Go 1.12 because it's already EOL.