### PR TITLE
Omit S3 directory object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,4 @@ fixture:
 	aws s3 --endpoint-url http://localhost:4572 mb s3://example-bucket-dryrun
 	aws s3 --endpoint-url http://localhost:4572 cp README.md s3://example-bucket-dryrun/dest_only_file
 	aws s3 --endpoint-url http://localhost:4572 mb s3://example-bucket-directory
-	touch .empty_file
-	aws s3 --endpoint-url http://localhost:4572 cp .empty_file s3://example-bucket-directory/test/
-	rm .empty_file
+	aws s3api --endpoint-url http://localhost:4572 put-object --bucket example-bucket-directory --key test/

--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,7 @@ fixture:
 	aws s3 --endpoint-url http://localhost:4572 cp README.md s3://example-bucket-delete/dest_only_file
 	aws s3 --endpoint-url http://localhost:4572 mb s3://example-bucket-dryrun
 	aws s3 --endpoint-url http://localhost:4572 cp README.md s3://example-bucket-dryrun/dest_only_file
+	aws s3 --endpoint-url http://localhost:4572 mb s3://example-bucket-directory
+	touch .empty_file
+	aws s3 --endpoint-url http://localhost:4572 cp .empty_file s3://example-bucket-directory/test/
+	rm .empty_file

--- a/s3sync.go
+++ b/s3sync.go
@@ -338,6 +338,10 @@ func (m *Manager) listS3FileWithToken(c chan *fileInfo, path *s3Path, token *str
 	}
 
 	for _, object := range list.Contents {
+		if strings.HasSuffix(*object.Key, "/") {
+			// Skip directory like object
+			continue
+		}
 		name, err := filepath.Rel(path.bucketPrefix, *object.Key)
 		if err != nil {
 			sendErrorInfoToChannel(c, err)

--- a/s3sync_test.go
+++ b/s3sync_test.go
@@ -79,6 +79,18 @@ func TestS3sync(t *testing.T) {
 		fileHasSize(t, filepath.Join(temp, "foo", dummyFilename), dummyFileSize)
 		fileHasSize(t, filepath.Join(temp, "bar/baz", dummyFilename), dummyFileSize)
 	})
+	t.Run("DownloadSkipDirectory", func(t *testing.T) {
+		temp, err := ioutil.TempDir("", "s3synctest")
+		defer os.RemoveAll(temp)
+
+		if err != nil {
+			t.Fatal("Failed to create temp dir")
+		}
+
+		if err := New(getSession()).Sync("s3://example-bucket-directory", temp); err != nil {
+			t.Fatal("Sync should be successful", err)
+		}
+	})
 	t.Run("Upload", func(t *testing.T) {
 		temp, err := ioutil.TempDir("", "s3synctest")
 		defer os.RemoveAll(temp)


### PR DESCRIPTION
S3 may have directory object and causes error like:
```
Downloading path/to/file to /path/to/base/dir/file
error: open /path/to/base: is a directory
```
https://docs.aws.amazon.com/AmazonS3/latest/user-guide/using-folders.html