### PR TITLE
URL Escaped Characters Support for Bucket Keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-LOCALSTACK_VERSION = 2.2.0
+LOCALSTACK_VERSION = 2.3.2
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ fixture:
 	aws s3 --endpoint-url http://localhost:4572 cp README.md s3://s3-source/foo/
 	aws s3 --endpoint-url http://localhost:4572 cp README.md s3://s3-source/bar/baz/
 	aws s3 --endpoint-url http://localhost:4572 mb s3://s3-destination
+	aws s3 --endpoint-url http://localhost:4572 mb s3://example-bucket-escaped
 	aws s3 --endpoint-url http://localhost:4572 mb s3://example-bucket-upload
 	aws s3 --endpoint-url http://localhost:4572 cp README.md s3://example-bucket-upload/dest_only_file
 	aws s3 --endpoint-url http://localhost:4572 mb s3://example-bucket-upload-file

--- a/s3path.go
+++ b/s3path.go
@@ -32,10 +32,15 @@ func urlToS3Path(url *url.URL) (*s3Path, error) {
 		return nil, errNoBucketName
 	}
 
+	path := url.RawPath
+	if path == "" {
+		path = url.Path
+	}
+
 	return &s3Path{
 		bucket: url.Host,
 		// Using filepath.ToSlash for change backslash to slash on Windows
-		bucketPrefix: strings.TrimPrefix(filepath.ToSlash(url.Path), "/"),
+		bucketPrefix: strings.TrimPrefix(filepath.ToSlash(path), "/"),
 	}, nil
 }
 

--- a/s3path.go
+++ b/s3path.go
@@ -34,6 +34,7 @@ func urlToS3Path(url *url.URL) (*s3Path, error) {
 
 	path := url.RawPath
 	if path == "" {
+		// If the path doesn't contain any special characters, RawPath would be empty
 		path = url.Path
 	}
 

--- a/s3path_test.go
+++ b/s3path_test.go
@@ -14,6 +14,7 @@
 package s3sync
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
 )
@@ -37,6 +38,24 @@ func TestURLToS3Path(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		if p.bucket != "bucket" || p.bucketPrefix != "test" {
+			t.Fatalf("Unexpected s3Path: %v", p)
+		}
+	})
+	t.Run("UrlEscapedPath", func(t *testing.T) {
+		urlHost := "bucket"
+		urlPath := url.QueryEscape("test/it")
+		srUrl, err := url.Parse(fmt.Sprintf("s3://%s/%s", urlHost, urlPath))
+
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		p, err := urlToS3Path(srUrl)
+
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if p.bucket != urlHost || p.bucketPrefix != urlPath {
 			t.Fatalf("Unexpected s3Path: %v", p)
 		}
 	})

--- a/s3path_test.go
+++ b/s3path_test.go
@@ -43,7 +43,7 @@ func TestURLToS3Path(t *testing.T) {
 	})
 	t.Run("UrlEscapedPath", func(t *testing.T) {
 		urlHost := "bucket"
-		urlPath := url.QueryEscape("test/it")
+		urlPath := fmt.Sprintf("space /%s", url.QueryEscape("test/it"))
 		srUrl, err := url.Parse(fmt.Sprintf("s3://%s/%s", urlHost, urlPath))
 
 		if err != nil {


### PR DESCRIPTION
This fix is related #349

With this correctly handles key names with. url encoded characters

I've added according test cases

Yet integration case for now is skipped since `localstack` experiences the very same issue it self. Fortunately looks they are on [their way for a fix](https://github.com/localstack/localstack/issues/8174#issuecomment-1584673754) as well 