### PR TITLE
Migrate sync log to awscli v2 style

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,11 +17,8 @@ import "log"
 // LoggerIF is the logger interface which this library requires.
 type LoggerIF interface {
 	// Log inserts a log entry. Arguments are handled in the manner
-	// of fmt.Print.
-	Log(v ...interface{})
-	// Log inserts a log entry. Arguments are handled in the manner
 	// of fmt.Printf.
-	Logf(format string, v ...interface{})
+	Logf(format string, v ...any)
 }
 
 // Logger is the logger instance.
@@ -32,10 +29,10 @@ func SetLogger(l LoggerIF) {
 	logger = l
 }
 
-func println(v ...interface{}) {
+func logf(format string, v ...any) {
 	if logger == nil {
-		log.Println(v...)
+		log.Printf(format, v...)
 		return
 	}
-	logger.Log(v...)
+	logger.Logf(format, v...)
 }

--- a/s3path.go
+++ b/s3path.go
@@ -16,6 +16,7 @@ package s3sync
 import (
 	"errors"
 	"net/url"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -47,4 +48,8 @@ func urlToS3Path(url *url.URL) (*s3Path, error) {
 
 func (p *s3Path) String() string {
 	return "s3://" + p.bucket + "/" + p.bucketPrefix
+}
+
+func (p *s3Path) joinedURL(s string) string {
+	return "s3://" + p.bucket + "/" + path.Join(p.bucketPrefix, s)
 }

--- a/s3sync.go
+++ b/s3sync.go
@@ -265,7 +265,9 @@ func (m *Manager) syncS3ToLocal(ctx context.Context, chJob chan func(), sourcePa
 func (m *Manager) copyS3ToS3(ctx context.Context, file *fileInfo, sourcePath *s3Path, destPath *s3Path) error {
 	copySource := filepath.ToSlash(filepath.Join(sourcePath.bucket, sourcePath.bucketPrefix, file.name))
 	destinationKey := filepath.ToSlash(filepath.Join(destPath.bucketPrefix, file.name))
-	println("Copying from", copySource, "to key", destinationKey, "in bucket", destPath.bucket)
+
+	logf("copy: %s to %s", sourcePath.joinedURL(file.name), destPath.joinedURL(file.name))
+
 	if m.dryrun {
 		return nil
 	}
@@ -295,7 +297,8 @@ func (m *Manager) download(ctx context.Context, file *fileInfo, sourcePath *s3Pa
 	}
 	targetDir := filepath.Dir(targetFilename)
 
-	println("Downloading", file.name, "to", targetFilename)
+	logf("download: %s to %s", sourcePath.joinedURL(file.name), targetFilename)
+
 	if m.dryrun {
 		return nil
 	}
@@ -345,7 +348,8 @@ func (m *Manager) deleteLocal(ctx context.Context, file *fileInfo, destPath stri
 		targetFilename = filepath.Join(destPath, file.name)
 	}
 
-	println("Deleting", targetFilename)
+	logf("delete: %s", targetFilename)
+
 	if m.dryrun {
 		return nil
 	}
@@ -372,7 +376,8 @@ func (m *Manager) upload(ctx context.Context, file *fileInfo, sourcePath string,
 		destFile.bucketPrefix = filepath.ToSlash(filepath.Join(destPath.bucketPrefix, file.name))
 	}
 
-	println("Uploading", file.name, "to", destFile.String())
+	logf("upload: %s to %s", file.name, destFile.String())
+
 	if m.dryrun {
 		return nil
 	}
@@ -399,7 +404,7 @@ func (m *Manager) upload(ctx context.Context, file *fileInfo, sourcePath string,
 
 	_, err = manager.NewUploader(
 		m.s3,
-		m.uploaderOpts...
+		m.uploaderOpts...,
 	).Upload(ctx, &s3.PutObjectInput{
 		Bucket:      &destFile.bucket,
 		Key:         &destFile.bucketPrefix,
@@ -422,7 +427,8 @@ func (m *Manager) deleteRemote(ctx context.Context, file *fileInfo, destPath *s3
 		destFile.bucketPrefix = filepath.ToSlash(filepath.Join(destPath.bucketPrefix, file.name))
 	}
 
-	println("Deleting", destFile.String())
+	logf("delete: %s", destFile.String())
+
 	if m.dryrun {
 		return nil
 	}


### PR DESCRIPTION
Original log style was intended to be:
```
Uploading path/to/file to s3://bucket/path/to/file
```
but actually it was:
```
Uploadingpath/to/filetos3://bucket/path/to/file
```


Fix spacing and also migrate the style to awscli v2 style:
```
upload: path/to/file to s3://bucket/path/to/file
```