### PR TITLE
Drop Sync without context

### DIFF
--- a/s3sync.go
+++ b/s3sync.go
@@ -98,13 +98,8 @@ func New(cfg aws.Config, options ...Option) *Manager {
 }
 
 // Sync syncs the files between s3 and local disks.
-func (m *Manager) Sync(source, dest string) error {
-	return m.SyncWithContext(context.Background(), source, dest)
-}
-
-// SyncWithContext syncs the files between s3 and local disks.
 // The context will be used for operation cancellation.
-func (m *Manager) SyncWithContext(ctx context.Context, source, dest string) error {
+func (m *Manager) Sync(ctx context.Context, source, dest string) error {
 	sourceURL, err := url.Parse(source)
 	if err != nil {
 		return err
@@ -399,7 +394,7 @@ func (m *Manager) upload(ctx context.Context, file *fileInfo, sourcePath string,
 
 	_, err = manager.NewUploader(
 		m.s3,
-		m.uploaderOpts...
+		m.uploaderOpts...,
 	).Upload(ctx, &s3.PutObjectInput{
 		Bucket:      &destFile.bucket,
 		Key:         &destFile.bucketPrefix,


### PR DESCRIPTION
Drop old `Sync` without `context.Context` and rename `SyncWithContext` to `Sync`