### PR TITLE
Remove Go 1.22 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         go_version:
-          - '1.22'
           - '1.23'
           - '1.24'
           - '1.25'


### PR DESCRIPTION
`actions/setup-go` v5 seems installed Go 1.23 for 1.22 build.

```
Run actions/setup-go@v5
Setup go version spec 1.22
Found in cache @ /opt/hostedtoolcache/go/1.22.12/x64
Added go to the path
Successfully set up Go version 1.22
go: downloading go1.23.0 (linux/amd64)
/opt/hostedtoolcache/go/1.22.12/x64/bin/go env GOMODCACHE
/opt/hostedtoolcache/go/1.22.12/x64/bin/go env GOCACHE
/home/runner/go/pkg/mod
/home/runner/.cache/go-build
Cache hit for: setup-go-Linux-x64-ubuntu24-go-1.23.0-3c96ed53ae24afad6856fe0ec43f87e2150f9dfcd0929f2cbe0d3edbf2b1d704
Received 134217728 of 365912600 (36.7%), 127.7 MBs/sec
Received 297795584 of 365912600 (81.4%), 141.8 MBs/sec
Received 365912600 of 365912600 (100.0%), 138.2 MBs/sec
Cache Size: ~349 MB (365912600 B)
/usr/bin/tar -xf /home/runner/work/_temp/405a1ca2-b895-4d19-b579-30f21c0e51ba/cache.tzst -P -C /home/runner/work/s3sync/s3sync --use-compress-program unzstd
/usr/bin/tar: ../../../go/pkg/mod/golang.org/x/telemetry/config@v0.65.0/LICENSE: Cannot open: File exists
...
 /usr/bin/tar: ../../../go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/SECURITY.md: Cannot open: File exists
/usr/bin/tar: Exiting with failure status due to previous errors
Warning: Failed to restore: "/usr/bin/tar" failed with error: The process '/usr/bin/tar' failed with exit code 2
Cache is not found
go version go1.23.0 linux/amd64
```